### PR TITLE
Add logic to allow skipping mcpl and ncrystal on aarch64 / ppc64le

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   folder: src
 
 build:
-  number: 0
+  number: 1
 
 outputs:
 
@@ -111,8 +111,8 @@ outputs:
         - {{ pin_subpackage('mcstas-data', max_pin="x.x.x") }}
         - {{ pin_subpackage('mcstas-mcgui', max_pin="x.x.x") }}
         - {{ pin_subpackage('mcstas-vis', max_pin="x.x.x") }}
-        - ncrystal  # [unix]
-        - mcpl  # [unix]
+        - ncrystal  # [unix and not aarch64 or ppc64le]
+        - mcpl  # [unix and not aarch64 or ppc64le]
 
 about:
   home: https://mcstas.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   folder: src
 
 build:
-  number: 1
+  number: 2
 
 outputs:
 
@@ -111,8 +111,8 @@ outputs:
         - {{ pin_subpackage('mcstas-data', max_pin="x.x.x") }}
         - {{ pin_subpackage('mcstas-mcgui', max_pin="x.x.x") }}
         - {{ pin_subpackage('mcstas-vis', max_pin="x.x.x") }}
-        - ncrystal  # [unix and not aarch64 or ppc64le]
-        - mcpl  # [unix and not aarch64 or ppc64le]
+        - ncrystal  # [unix and not (aarch64 or ppc64le)]
+        - mcpl  # [unix and not (aarch64 or ppc64le)]
 
 about:
   home: https://mcstas.org/


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This may allow us to build for Linux platforms aarch64 + ppc64le (without mcpl and ncrystal for now)
