### PR TITLE
Last attempt at enabling mpi runtime test on linux

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   folder: src
 
 build:
-  number: 0
+  number: 1
 
 outputs:
 
@@ -42,6 +42,8 @@ outputs:
     test:
       files:
         - test_pkg.py
+      requires:
+        - openssh  # [linux]
       commands:
         - python test_pkg.py core
       source_files:

--- a/recipe/test_pkg.py
+++ b/recipe/test_pkg.py
@@ -192,8 +192,10 @@ def tests_for_pkg_mcstas():
 
     #MPI test
     if 'linux' in platform.system().lower():
-        print('linux detected - MPI compile only')
-        run_instrument_file( 'share/mcstas/resources/examples/BNL/BNL_H8/BNL_H8.instr', 'lambda=2.36 -s1000 -n0 --mpi=2 --verbose')
+        print('linux detected - special MPI handling')
+        os.environ["OMPI_MCA_plm_rsh_agent"] = "ssh"
+        os.environ["OMPI_MCA_plm_ssh_agent"] = "ssh"
+        run_instrument_file( 'share/mcstas/resources/examples/BNL/BNL_H8/BNL_H8.instr', 'lambda=2.36 -s1000 -n1e5 --mpi=2 --verbose')
     else:
         run_instrument_file( 'share/mcstas/resources/examples/BNL/BNL_H8/BNL_H8.instr', 'lambda=2.36 -s1000 -n1e5 --mpi=2 --verbose')
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
